### PR TITLE
recipes-qim-product-sdk: use ${PN} instead of actual recipe name

### DIFF
--- a/recipes-qim-product-sdk/packagegroups/packagegroup-qcom-gst.bbappend
+++ b/recipes-qim-product-sdk/packagegroups/packagegroup-qcom-gst.bbappend
@@ -1,4 +1,4 @@
-RDEPENDS:packagegroup-qcom-gst:append:qcom-custom-bsp = "  \
+RDEPENDS:${PN}:append:qcom-custom-bsp = "  \
         qcom-gstreamer1.0-plugins-oss-mlsnpe \
         qcom-gstreamer1.0-plugins-oss-mlqnn \
         qcom-gstreamer1.0-plugins-oss-mltflite \


### PR DESCRIPTION
using RDEPENDS:${PN} instead of RDEPENDS:packagegroup-qcom-gst avoids warning during compilation.