### PR TITLE
meta-qcom-qim-product-sdk: Drop SRI_URI

### DIFF
--- a/recipes-qim-product-sdk/packagegroups/packagegroup-qcom-qim-product.bb
+++ b/recipes-qim-product-sdk/packagegroups/packagegroup-qcom-qim-product.bb
@@ -7,8 +7,6 @@ PACKAGE_ARCH = "${SOC_ARCH}"
 
 inherit packagegroup
 
-SRC_URI += "file://install.sh"
-
 PACKAGES = "${PN}"
 
 RDEPENDS:${PN}:qcom-custom-bsp = " \


### PR DESCRIPTION
install.sh doesn't exist in any path for this recipe. A non-existent file in SRC_URI would lead an error while creating SPDX SBoM.